### PR TITLE
use UNNEST/STRUCT for explicit inline tuple typing

### DIFF
--- a/models/labels/cex/labels_cex_ethereum.sql
+++ b/models/labels/cex/labels_cex_ethereum.sql
@@ -6,13 +6,13 @@
 
 SELECT blockchain, address, name, category, contributor, source, created_at, updated_at
 {% if var('declare_values_with_unnest') %}
-{% set ARRAY_start = '[' %}
-{% set ARRAY_end = ']' %}
+{% set array_start = '[' %}
+{% set array_end = ']' %}
 FROM UNNEST([
 STRUCT<blockchain ARRAY<STRING>, address STRING, name STRING, category STRING, contributor STRING, source STRING, created_at TIMESTAMP, updated_at TIMESTAMP>
 {% else %}
-{% set ARRAY_start = '{% array_start %}(' %}
-{% set ARRAY_end = ')' %}
+{% set array_start = '{% array_start %}(' %}
+{% set array_end = ')' %}
 FROM (VALUES
 {% endif %}
     -- Binance, Source: https://etherscan.io/accounts/label/binance

--- a/models/labels/funds/labels_funds_ethereum.sql
+++ b/models/labels/funds/labels_funds_ethereum.sql
@@ -2,13 +2,13 @@
 
 SELECT blockchain, address, name, category, contributor, source, created_at, updated_at
 {% if var('declare_values_with_unnest') %}
-{% set ARRAY_start = '[' %}
-{% set ARRAY_end = ']' %}
+{% set array_start = '[' %}
+{% set array_end = ']' %}
 FROM UNNEST([
 STRUCT<blockchain ARRAY<STRING>, address STRING, name STRING, category STRING, contributor STRING, source STRING, created_at TIMESTAMP, updated_at TIMESTAMP>
 {% else %}
-{% set ARRAY_start = '{% array_start %}(' %}
-{% set ARRAY_end = ')' %}
+{% set array_start = '{% array_start %}(' %}
+{% set array_end = ')' %}
 FROM (VALUES
 {% endif %}
      ({% array_start %}'ethereum'{% array_end %},'0x2B1Ad6184a6B0fac06bD225ed37C2AbC04415fF4', 'a16z', 'funds', 'soispoke', 'static', timestamp('2022-09-03'), now())

--- a/models/labels/hackers/labels_hackers_ethereum.sql
+++ b/models/labels/hackers/labels_hackers_ethereum.sql
@@ -6,13 +6,13 @@
 
 SELECT blockchain, address, name, category, contributor, source, created_at, updated_at
 {% if var('declare_values_with_unnest') %}
-{% set ARRAY_start = '[' %}
-{% set ARRAY_end = ']' %}
+{% set array_start = '[' %}
+{% set array_end = ']' %}
 FROM UNNEST([
 STRUCT<blockchain ARRAY<STRING>, address STRING, name STRING, category STRING, contributor STRING, source STRING, created_at TIMESTAMP, updated_at TIMESTAMP>
 {% else %}
-{% set ARRAY_start = '{% array_start %}(' %}
-{% set ARRAY_end = ')' %}
+{% set array_start = '{% array_start %}(' %}
+{% set array_end = ')' %}
 FROM (VALUES
 {% endif %}
 ({% array_start %}'ethereum'{% array_end %},'0xb3764761e297d6f121e79c32a65829cd1ddb4d32','Multisig Exploit Hacker','hackers','ilemi','static', timestamp('2022-08-28'), now()),

--- a/models/labels/multisig/labels_multisig_ethereum.sql
+++ b/models/labels/multisig/labels_multisig_ethereum.sql
@@ -6,13 +6,13 @@
 
 SELECT blockchain, address, name, category, contributor, source, created_at, updated_at
 {% if var('declare_values_with_unnest') %}
-{% set ARRAY_start = '[' %}
-{% set ARRAY_end = ']' %}
+{% set array_start = '[' %}
+{% set array_end = ']' %}
 FROM UNNEST([
 STRUCT<blockchain ARRAY<STRING>, address STRING, name STRING, category STRING, contributor STRING, source STRING, created_at TIMESTAMP, updated_at TIMESTAMP>
 {% else %}
-{% set ARRAY_start = '{% array_start %}(' %}
-{% set ARRAY_end = ')' %}
+{% set array_start = '{% array_start %}(' %}
+{% set array_end = ')' %}
 FROM (VALUES
 {% endif %}
 ({% array_start %}'ethereum'{% array_end %},'0x4f3a120e72c76c22ae802d129f599bfdbc31cb81','Wintermute Trading: MultiSig','multisig','ilemi','static',timestamp('2022-09-28'), now()),    

--- a/models/labels/ofac_sanctionned/labels_ofac_sanctionned_ethereum.sql
+++ b/models/labels/ofac_sanctionned/labels_ofac_sanctionned_ethereum.sql
@@ -6,13 +6,13 @@
 
 SELECT blockchain, address, name, category, contributor, source, created_at, updated_at
 {% if var('declare_values_with_unnest') %}
-{% set ARRAY_start = '[' %}
-{% set ARRAY_end = ']' %}
+{% set array_start = '[' %}
+{% set array_end = ']' %}
 FROM UNNEST([
 STRUCT<blockchain ARRAY<STRING>, address STRING, name STRING, category STRING, contributor STRING, source STRING, created_at TIMESTAMP, updated_at TIMESTAMP>
 {% else %}
-{% set ARRAY_start = '{% array_start %}(' %}
-{% set ARRAY_end = ')' %}
+{% set array_start = '{% array_start %}(' %}
+{% set array_end = ')' %}
 FROM (VALUES
 {% endif %}
     -- Source: https://home.treasury.gov/policy-issues/financial-sanctions/recent-actions/20220808

--- a/models/labels/validators/labels_validators_bnb.sql
+++ b/models/labels/validators/labels_validators_bnb.sql
@@ -6,13 +6,13 @@
 
 SELECT blockchain, lower(address) as address, name, category, contributor, source, created_at, updated_at
 {% if var('declare_values_with_unnest') %}
-{% set ARRAY_start = '[' %}
-{% set ARRAY_end = ']' %}
+{% set array_start = '[' %}
+{% set array_end = ']' %}
 FROM UNNEST([
 STRUCT<blockchain ARRAY<STRING>, address STRING, name STRING, category STRING, contributor STRING, source STRING, created_at TIMESTAMP, updated_at TIMESTAMP>
 {% else %}
-{% set ARRAY_start = '{% array_start %}(' %}
-{% set ARRAY_end = ')' %}
+{% set array_start = '{% array_start %}(' %}
+{% set array_end = ')' %}
 FROM (VALUES
 {% endif %}
     -- Binance, Source: https://etherscan.io/accounts/label/binance


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
